### PR TITLE
fix: pass file attachments from composer through to gateway RPC

### DIFF
--- a/src/lib/components/ChatView.svelte
+++ b/src/lib/components/ChatView.svelte
@@ -188,9 +188,9 @@
 		}, 2000);
 	}
 
-	function handleSend(message: string) {
+	function handleSend(message: string, attachments?: File[]) {
 		if (!chatSession) return;
-		chatSession.send(message);
+		chatSession.send(message, attachments);
 	}
 
 	function handleAbort() {


### PR DESCRIPTION
## Problem
MessageComposer passes (message, attachments) to onSend, but ChatView.handleSend only accepted (message: string) — dropping attachments entirely. The chat store send() also had no attachment support.

## Fix
- ChatView.svelte: handleSend now accepts and forwards attachments
- chat.ts: send() encodes files as base64 and includes them in the chat.send RPC payload

## Testing
Attach a file in Falcon Dash chat — it should now reach the agent.