### PR TITLE
feat: embed gateway control UI in settings tab

### DIFF
--- a/src/lib/components/settings/GatewayControlTab.svelte
+++ b/src/lib/components/settings/GatewayControlTab.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { get } from 'svelte/store';
+	import { gatewayUrl } from '$lib/stores/token.js';
+
+	let controlUrl = $state<string | null>(null);
+	let error = $state<string | null>(null);
+
+	$effect(() => {
+		const wsUrl = get(gatewayUrl);
+		try {
+			const httpUrl = wsUrl.replace(/^ws(s?)/, 'http$1');
+			const url = new URL(httpUrl);
+			controlUrl = url.origin;
+		} catch {
+			error = 'No gateway URL configured. Connect to a gateway first.';
+		}
+	});
+</script>
+
+<div class="flex h-full flex-col">
+	{#if error}
+		<div class="flex flex-1 items-center justify-center">
+			<p class="text-sm text-gray-400">{error}</p>
+		</div>
+	{:else if controlUrl}
+		<iframe
+			src={controlUrl}
+			title="Gateway Control UI"
+			class="h-full w-full flex-1 border-0"
+			sandbox="allow-same-origin allow-scripts allow-forms allow-popups"
+		></iframe>
+	{/if}
+</div>

--- a/src/lib/components/settings/SettingsPage.svelte
+++ b/src/lib/components/settings/SettingsPage.svelte
@@ -11,6 +11,7 @@
 	import AgentsTab from './AgentsTab.svelte';
 	import WorkspaceFiles from './WorkspaceFiles.svelte';
 	import CanvasDiagnosticsTab from './CanvasDiagnosticsTab.svelte';
+	import GatewayControlTab from './GatewayControlTab.svelte';
 
 	const tabs = [
 		{ id: 'user', label: 'User', component: UserTab },
@@ -24,6 +25,7 @@
 		{ id: 'approvals', label: 'Approvals', component: ExecApprovals },
 		{ id: 'workspace', label: 'Workspace', component: WorkspaceFiles },
 		{ id: 'canvas', label: 'Canvas', component: CanvasDiagnosticsTab },
+		{ id: 'gateway-control', label: 'Gateway Control', component: GatewayControlTab },
 		{ id: 'about', label: 'About', component: AboutTab }
 	] as const;
 

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -1,22 +1,12 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { get } from 'svelte/store';
-	import { gatewayUrl } from '$lib/stores/token.js';
-
-	let message = $state('Redirecting to gateway setup…');
+	import { goto } from '$app/navigation';
 
 	onMount(() => {
-		const wsUrl = get(gatewayUrl);
-		try {
-			const httpUrl = wsUrl.replace(/^ws(s?)/, 'http$1');
-			const url = new URL(httpUrl);
-			window.location.href = url.origin;
-		} catch {
-			message = 'No gateway URL configured. Connect to a gateway first.';
-		}
+		goto('/settings', { replaceState: true });
 	});
 </script>
 
 <div class="flex h-screen items-center justify-center bg-gray-950">
-	<p class="text-sm text-gray-400">{message}</p>
+	<p class="text-sm text-gray-400">Redirecting to settings…</p>
 </div>


### PR DESCRIPTION
Closes #280

## Changes

### New: `GatewayControlTab.svelte`
- Derives the gateway HTTP origin from the WebSocket URL in `gatewayUrl` store
- Renders the gateway control UI in a sandboxed `<iframe>`
- Shows fallback message if no gateway URL is configured

### Updated: `SettingsPage.svelte`
- Added 'Gateway Control' tab (before About)

### Updated: `/setup` route
- Now redirects to `/settings` instead of the external gateway URL

## Notes
- If the gateway sets `X-Frame-Options: DENY`, the iframe won't render — that header would need to be relaxed on the gateway side
- Mobile settings already has a Gateway entry (AdvancedPage) — no mobile changes needed